### PR TITLE
Allow manually created events (e.g. from test frameworks) to trigger bindings.

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -379,7 +379,7 @@
                 // For each property in the jwertyCode object, compare to `event`
                 for (var p in jwertyCode[n]) {
                     // ...except for jwertyCode.jwertyCombo...
-                    if (p !== 'jwertyCombo' && event[p] !== jwertyCode[n][p]) returnValue = false;
+                    if (p !== 'jwertyCombo' && event[p] != jwertyCode[n][p]) returnValue = false;
                 }
                 // If this jwertyCode optional wasn't falsey, then we can return early.
                 if (returnValue !== false) return returnValue;


### PR DESCRIPTION
Events created using jQuery.Event('keydown', {keyCode: XX}) or Zepto.Event('keydown', {keyCode: XX}) do not fire because they don't have ctrlKey etc. explicitly set to false.

Changing the strict equality test in .is() to non-strict allows events with these properties undefined to still trigger events.
