### PR TITLE
Bridge for CanJS Library

### DIFF
--- a/jwerty.canBridge.js
+++ b/jwerty.canBridge.js
@@ -1,0 +1,35 @@
+steal('can/control/modifier', './jwerty.js' function(Control){
+
+/**
+ * Add templated-event-binding with keydown specific bindings
+ * into CanJS(http://www.canjs.us) JavaScript framework.
+ *
+ * For example, the following would bind to keydown on "CTRL+P".
+ *
+ *	can.Control({
+ * 		"keydown:(ctrl+p)":function(elm,ev){
+ *			console.log("ctrl+p was pressed");
+ *		}
+ * 	});
+ *
+ */
+
+// Hang on to original action
+var originalShifter = can.Control._shifter;
+
+// Redefine _isAction to handle new syntax
+can.extend( can.Control, {
+
+	_shifter: function( context, name ) {
+			var fn = originalShifter.apply( this, arguments ),
+			    parts = name.split(":");
+
+		if ( parts[1] && parts[0] === "keydown" ) {
+			fn = jwerty.event(parts[1].replace(/\(|\)/gi,''), fn);
+		}
+
+		return fn;
+	}
+});
+
+});


### PR DESCRIPTION
I added integration for CanJS ( http://www.canjs.us ) .

This addition, allows deep integration with our templated-event-binding ( http://canjs.us/#can_control-templated_event_handlers_pt_1 ) .  

This integration allows you to do 'jwerty' style binding with our native-like API.  For example:

can.Control({
   "keydown:(ctrl+p)":function(){ .... }
});

Thanks!
