### PR TITLE
Don't override real global object

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -463,4 +463,4 @@
         KEYS: _keys
     };
     
-}(this, (typeof module !== 'undefined' && module.exports ? module.exports : this)));
+}(global || this, (typeof module !== 'undefined' && module.exports ? module.exports : this)));


### PR DESCRIPTION
Example of problem:

For code:

``` js
$ = global.$ = global.jQuery = require('jquery')
jwerty = require('jwerty').jwerty

// ...

jwerty.fire('esc', $el)
```

I've got: "TypeError: Expecting a function in instanceof check, but got [object Object]".

When I put console output to this code:

``` js
(function (global, exports) {

    console.log('#######')
    console.log('Global:')
    console.log(global)
    console.log('jQuery:')
    console.log(global.jQuery)
    console.log('#######')

    // Helper methods & vars:
    var $d = global.document
    ,   $ = (global.jQuery || global.Zepto || global.ender || $d)
    ,   $$
    ,   $b
    ,   ke = 'keydown';

    // ...
```

Output:

```
#######
Global:
{}
jQuery:
undefined
#######
```

This happen because `this != global` in require:

``` sh
$ node
> this === global
true
```

but

``` sh
$ cat example.js                                                                                                                                                                                console.log(this === global)
$ node
> require('./example')
false
```
