### PR TITLE
Adding support for multiple combos syntax

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -262,7 +262,6 @@
 		    var matched = [], keys, key;
 		    for(i = 0; i < codes.length; i++){
 			    keys = codes[i].split("+");
-			    console.log(keys);
 
 			    // This loop will cleanup strings and combine keys into array
 			    // if the key is in-string-array like "cmd+[a,b,c]"


### PR DESCRIPTION
I've added support for "multiple combos" as alternative of many combox separated by slash.
You can now write

``` javascript
jwerty.is("cmd+[a,b,c]", event)
jwerty.is("cmd+shift+[a,b,c]", event)
jwerty.is("[ctrl, cmd]+a", event)
```

instead of

``` javascript
jwerty.is("cmd+a/cmd+b/cmd+c", event)
jwerty.is("cmd+shift+a/cmd+shift+b/cmd+shift+c", event)
jwerty.is("cmd+a/ctrl+a", event)
```

And next example demonstrates the power of new syntax.

Old style:

``` javascript
jwerty.is("backspace/backspace+ctrl/backspace+cmd/backspace+alt/delete/delete+ctrl/delete+cmd/delete+alt", event)
```

New style:

``` javascript
jwerty.is("backspace/backspace+[cmd,ctrl,alt]/delete/delete+[cmd,ctrl,alt]", event)
```

This syntax works like abbreviations and my code just expands it into full combo.
Everything from old syntax (such as `[a-z]` or `[0-9]`) works as usual.
