### PR TITLE
Fix npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,10 @@
       "url": "http://www.opensource.org/licenses/mit-license.php"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/keithamus/jwerty"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keithamus/jwerty"
+  },
   "main": "./jwerty.js",
   "ender": "./jwerty.enderBridge.js"
 }


### PR DESCRIPTION
Fixes `npm WARN package.json jwerty@0.3.2 'repositories' (plural) Not supported. Please pick one as the 'repository' field"`
