### PR TITLE
Update jwerty.js

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -449,7 +449,7 @@
                 // For each property in the jwertyCode object, compare to `event`
                 for (var p in jwertyCode[n]) {
                     // ...except for jwertyCode.jwertyCombo...
-                    if (p !== 'jwertyCombo' && event[p] != jwertyCode[n][p]) returnValue = false;
+                    if (p !== 'jwertyCombo' && event[p] !== undefined && event[p] != jwertyCode[n][p]) returnValue = false;
                 }
                 // If this jwertyCode optional wasn't falsey, then we can return early.
                 if (returnValue !== false) return returnValue;


### PR DESCRIPTION
In some scenarios (e.g. Ctrl-Click) in Firefox and IE the event object does not have the keyCode property. Therefore the loop always returns false when comparing properties with the jwertycode object.

This check skips the comparison if the property is missing on the event object.