### PR TITLE
Fix incorrect module names

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -29,7 +29,7 @@
 
     // Helper methods & vars:
     var $d = global.document,
-        $ = (tryRequire('jquery') || tryRequire('zepto') || tryRequire('ender') || $d),
+        $ = (tryRequire('jQuery') || tryRequire('Zepto') || tryRequire('ender') || $d),
         $$, // Element selector function
         $b, // Event binding function
         $u, // Event unbinding function


### PR DESCRIPTION
If the "require" module is used it will decapitalize modules names in any way.
But if it's not used, `tryRequire` will try to return one of those modules from 
the global scope,and their actual names are "jQuery" and "Zepto".